### PR TITLE
[wip] Various documentation changes

### DIFF
--- a/.documentation/additional-resources.rst
+++ b/.documentation/additional-resources.rst
@@ -3,9 +3,9 @@
 Additional Resources
 ====================
 
-* Read the original blog post which started this module: `How to define a highly 
-  scalable folder structure for your Angular project 
+* Read the original blog post which started this module: `How to define a highly
+  scalable folder structure for your Angular project
   <https://itnext.io/choosing-a-highly-scalable-folder-structure-in-angular-d987de65ec7>`_
 
-* `Aliasing modules <https://www.npmjs.com/package/module-alias>`_ is a popular 
+* `Aliasing modules <https://www.npmjs.com/package/module-alias>`_ is a popular
   way to make your import statements more tidy.

--- a/.documentation/additional-resources.rst
+++ b/.documentation/additional-resources.rst
@@ -3,5 +3,9 @@
 Additional Resources
 ====================
 
-* Read the original blog post which started this module: `How to define a highly scalable folder structure for your Angular project <https://itnext.io/choosing-a-highly-scalable-folder-structure-in-angular-d987de65ec7>`_
-* `Aliasing modules <https://www.npmjs.com/package/module-alias>`_ is a popular way to make your import statements more tidy.
+* Read the original blog post which started this module: `How to define a highly 
+  scalable folder structure for your Angular project 
+  <https://itnext.io/choosing-a-highly-scalable-folder-structure-in-angular-d987de65ec7>`_
+
+* `Aliasing modules <https://www.npmjs.com/package/module-alias>`_ is a popular 
+  way to make your import statements more tidy.

--- a/.documentation/conf.py
+++ b/.documentation/conf.py
@@ -1,0 +1,1 @@
+master_doc = 'index'

--- a/.documentation/core.rst
+++ b/.documentation/core.rst
@@ -5,9 +5,11 @@ Core Module
 
 `~/src/app/core <../src/app/core>`_
 
-This module is the support system for the rest of the application.  Resources which are always loaded
-such as route guards, HTTP interceptors, and application level services such as the ThemeService in this
-application.  Other app services such as logging go in this module.
+This module is the support system for the rest of the application.  Resources 
+which are always loaded such as route guards, HTTP interceptors, and application 
+level services such as the ThemeService in this application.  Other app services 
+such as logging go in this module.
 
-This module is a good candidate for `module aliasing <additional-resources.rst>`_ such as aliasing 
-the module to **@app**
+This module is a good candidate for 
+`module aliasing <additional-resources.rst>`_ such as aliasing the module 
+to **@app**

--- a/.documentation/core.rst
+++ b/.documentation/core.rst
@@ -5,11 +5,11 @@ Core Module
 
 `~/src/app/core <../src/app/core>`_
 
-This module is the support system for the rest of the application.  Resources 
-which are always loaded such as route guards, HTTP interceptors, and application 
-level services such as the ThemeService in this application.  Other app services 
-such as logging go in this module.
+This module is the support system for the rest of the application.  Resources
+which are always loaded such as route guards, HTTP interceptors, and
+application level services such as the ThemeService in this application.  Other
+app services such as logging go in this module.
 
-This module is a good candidate for 
-`module aliasing <additional-resources.rst>`_ such as aliasing the module 
+This module is a good candidate for
+`module aliasing <additional-resources.rst>`_ such as aliasing the module
 to **@app**

--- a/.documentation/data.rst
+++ b/.documentation/data.rst
@@ -6,16 +6,16 @@ Data Module
 
 `~/src/app/data <../src/app/data>`_
 
-The data module is a top level directory and holds the schema (models/entities) 
+The data module is a top level directory and holds the schema (models/entities)
 and services (repositories) for data consumed by the application.
 
 By default there are two subdirectories::
 
   ~/src/app/data
     /schema
-    /service 
+    /service
 
-The schema directory holds the class definition files for data structures.  
+The schema directory holds the class definition files for data structures.
 An example data structure:
 
 .. code-block:: ts
@@ -26,34 +26,34 @@ An example data structure:
     thumbnail: string;
   }
 
-The service directory holds the services for fetching data.  
-The service files are not necessarily a 1:1 match with schema files.  
+The service directory holds the services for fetching data.
+The service files are not necessarily a 1:1 match with schema files.
 An example service file:
 
 .. code-block:: ts
 
   import { Injectable } from '@angular/core';
   import { Observable } from 'rxjs';
-  
+
   import { Project } from '../schema/project';
   import { ApiService } from './api.service';
-  
+
   const routes = {
       projects: '/projects',
       project: (id: number) =>  `/projects/${id}`
   };
-  
+
   @Injectable({
     providedIn: 'root'
   })
   export class ProjectService {
       constructor(
         private apiService: ApiService) {}
-  
+
       getAll(): Observable<Array<Project>> {
           return this.apiService.get(routes.projects);
       }
-  
+
       getSingle(id: number): Observable<Project> {
           return this.apiService.get(routes.project(id));
       }
@@ -63,9 +63,9 @@ An example service file:
 Multiple Data Sources
 ---------------------
 
-If your application consumes data from more than one source then the data 
-directory should be restructured to contain subdirectories for each data source.  
-Do not create multiple modules for each data source::
+If your application consumes data from more than one source then the data
+directory should be restructured to contain subdirectories for each data
+source.  Do not create multiple modules for each data source::
 
   ~/src/app/data
     /data-source-one
@@ -80,8 +80,8 @@ Do not create multiple modules for each data source::
 Schema Naming Standard
 ----------------------
 
-A schema file is very much like an entity file in an Object Relational Mapper.  
-This schema file is central to your application's consumption of data and 
-therefore does not need cursory decorators such as calling it `ProjectSchema` or
-`ProjectModel`.  Schemas are special because they are the only plain-named class 
-in the application.
+A schema file is very much like an entity file in an Object Relational Mapper.
+This schema file is central to your application's consumption of data and
+therefore does not need cursory decorators such as calling it `ProjectSchema`
+or `ProjectModel`.  Schemas are special because they are the only plain-named
+class in the application.

--- a/.documentation/data.rst
+++ b/.documentation/data.rst
@@ -6,8 +6,8 @@ Data Module
 
 `~/src/app/data <../src/app/data>`_
 
-The data module is a top level directory and holds the schema (models/entities) and services (repositories)
-for data consumed by the application.
+The data module is a top level directory and holds the schema (models/entities) 
+and services (repositories) for data consumed by the application.
 
 By default there are two subdirectories::
 
@@ -15,7 +15,8 @@ By default there are two subdirectories::
     /schema
     /service 
 
-The schema directory holds the class definition files for data structures.  An example data structure:
+The schema directory holds the class definition files for data structures.  
+An example data structure:
 
 .. code-block:: ts
 
@@ -25,8 +26,9 @@ The schema directory holds the class definition files for data structures.  An e
     thumbnail: string;
   }
 
-The service directory holds the services for fetching data.  The service files are not necessarily 
-a 1:1 match with schema files.  An example service file:
+The service directory holds the services for fetching data.  
+The service files are not necessarily a 1:1 match with schema files.  
+An example service file:
 
 .. code-block:: ts
 
@@ -61,8 +63,9 @@ a 1:1 match with schema files.  An example service file:
 Multiple Data Sources
 ---------------------
 
-If your application consumes data from more than one source then the data directory should be restructured
-to contain subdirectories for each data source.  Do not create multiple modules for each data source::
+If your application consumes data from more than one source then the data 
+directory should be restructured to contain subdirectories for each data source.  
+Do not create multiple modules for each data source::
 
   ~/src/app/data
     /data-source-one
@@ -77,7 +80,8 @@ to contain subdirectories for each data source.  Do not create multiple modules 
 Schema Naming Standard
 ----------------------
 
-A schema file is very much like an entity file in an Object Relational Mapper.  This schema file is central
-to your application's consumption of data and therefore does not need cursory decorators such as calling it
-`ProjectSchema` or `ProjectModel`.  Schemas are special because they are the only plain-named class in the 
-application.
+A schema file is very much like an entity file in an Object Relational Mapper.  
+This schema file is central to your application's consumption of data and 
+therefore does not need cursory decorators such as calling it `ProjectSchema` or
+`ProjectModel`.  Schemas are special because they are the only plain-named class 
+in the application.

--- a/.documentation/index.rst
+++ b/.documentation/index.rst
@@ -10,18 +10,18 @@ Directory Structure
 Documentation is organized by the directories defined by this repository
 
 ~
-  * `media <media.rst>`_
-  * src
+  * /`media <media.rst>`_
+  * /src
 
-    * app 
+    * /app 
 
-      * `core <core.rst>`_
-      * `data <data.rst>`_
-      * `layout <layout.rst>`_
-      * `module <module.rst>`_
-      * `shared <shared.rst>`_
+      * /`core <core.rst>`_
+      * /`data <data.rst>`_
+      * /`layout <layout.rst>`_
+      * /`module <module.rst>`_
+      * /`shared <shared.rst>`_
 
-    * `theme <theme.rst>`_
+    * /`theme <theme.rst>`_
 
 Be sure to check our `additional resources <additional-resources.rst>`_ for further reading on how to improve access to and readability of your modules.
 

--- a/.documentation/index.rst
+++ b/.documentation/index.rst
@@ -1,7 +1,7 @@
 Angular Folder Structure
 ========================
 
-This project is an example of directory structure in an Angular application 
+This project is an example of directory structure in an Angular application
 and it is a working application.
 
 
@@ -14,7 +14,7 @@ Documentation is organized by the directories defined by this repository.
   * /`media <media.rst>`_
   * /src
 
-    * /app 
+    * /app
 
       * /`core <core.rst>`_
       * /`data <data.rst>`_
@@ -24,29 +24,31 @@ Documentation is organized by the directories defined by this repository.
 
     * /`theme <theme.rst>`_
 
-Be sure to check our `additional resources <additional-resources.rst>`_ for further reading on how to improve access to and readability of your modules.
+Be sure to check our `additional resources <additional-resources.rst>`_ for
+further reading on how to improve access to and readability of your
+directories.
 
 
 Demonstration Application
 -------------------------
 
-See this application running on our `demonstation application <https://mathisgarberg.github.io/angular-folder-structure/>`_
+See this application running on our
+`demonstation application <https://mathisgarberg.github.io/angular-folder-structure/>`_
 
 
 Installation
 ------------
 
-You can install this application locally and run it.  Assuming you already have ``typescript``, ``npm``, and ``ng`` installed, clone this repository, cd to the directory and run ``npm install``
-
-.. code-block::
+You can install this application locally and run it.  Assuming you already have
+``typescript``, ``npm``, and ``ng`` installed, clone this repository, cd to the
+directory and run ``npm install``::
 
   git clone https://github.com/mathisGarberg/angular-folder-structure.git
   cd angular-folder-structure
   npm install
 
-Included with this package are some custom npm scripts.  Here is a list of npm run commands and their descriptions:
-
-.. code-block::
+Included with this package are some custom npm scripts.  Here is a list of
+npm run commands and their descriptions::
 
   npm start     -> Run dev. server on http://localhost:4200/
   npm run build -> Lint code and build app for production in dist folder
@@ -56,7 +58,8 @@ Included with this package are some custom npm scripts.  Here is a list of npm r
   npm run lint  -> Lint code
 
 
-Run 
+Run
 ---
 
-To run the application type ``ng serve`` then browse to `http://localhost:4200/ <http://localhost:4200/>`_
+To run the application type ``ng serve`` then browse to
+`http://localhost:4200/ <http://localhost:4200/>`_

--- a/.documentation/index.rst
+++ b/.documentation/index.rst
@@ -22,3 +22,32 @@ Demonstration Application
 -------------------------
 
 See this application running on our `demonstation application <https://mathisgarberg.github.io/angular-folder-structure/>`_
+
+
+Installation
+------------
+
+You can install this application locally and run it.  Assuming you already have ``typescript``, ``npm``, and ``ng`` installed, clone this repository, cd to the directory and run ``npm install``
+
+.. code-block::
+
+  git clone https://github.com/mathisGarberg/angular-folder-structure.git
+  cd angular-folder-structure
+  npm install
+
+Included with this package are some custom npm scripts.  Here is a list of npm run commands and their descriptions:
+
+.. code-block::
+
+  npm start     -> Run dev. server on http://localhost:4200/
+  npm run build -> Lint code and build app for production in dist folder
+  npm run test  -> Run unit tests via Karma in watch mode
+  npm test:ci   -> Lint code and run unit tests once for continuous integration
+  npm run e2e   -> Run e2e tests using Protractor
+  npm run lint  -> Lint code
+
+
+Run 
+---
+
+To run the application type ``ng serve`` then browse to `http://localhost:4200/ <http://localhost:4200/>`_

--- a/.documentation/index.rst
+++ b/.documentation/index.rst
@@ -63,3 +63,14 @@ Run
 
 To run the application type ``ng serve`` then browse to
 `http://localhost:4200/ <http://localhost:4200/>`_
+
+
+Contributing
+------------
+
+We welcome contributions of all kinds to this repository.  Submit a PR
+or create an issue for anything you can help us improve.
+
+For documentation contributions we recommend you install
+`restructuredText <https://docs.restructuredtext.net/index.html>`_ into your
+copy of vscode so you can lint and preview your work before it is submitted.

--- a/.documentation/index.rst
+++ b/.documentation/index.rst
@@ -1,13 +1,14 @@
 Angular Folder Structure
 ========================
 
-This project is an example of directory structure in an Angular application but it is also a working application.
+This project is an example of directory structure in an Angular application 
+and it is a working application.
 
 
 Directory Structure
 -------------------
 
-Documentation is organized by the directories defined by this repository
+Documentation is organized by the directories defined by this repository.
 
 ~
   * /`media <media.rst>`_

--- a/.documentation/index.rst
+++ b/.documentation/index.rst
@@ -10,16 +10,19 @@ Directory Structure
 Documentation is organized by the directories defined by this repository
 
 ~
-├── `media <media.rst>`_
-└── src
-    ├── app
-    │   ├── `core <core.rst>`_
-    │   ├── `data <data.rst>`_
-    │   ├── `layout <layout.rst>`_
-    │   ├── `module <module.rst>`_
-    │   └── `shared <shared.rst>`_
-    └── `theme <theme.rst>`_
-    
+  * `media <media.rst>`_
+  * src
+
+    * app 
+
+      * `core <core.rst>`_
+      * `data <data.rst>`_
+      * `layout <layout.rst>`_
+      * `module <module.rst>`_
+      * `shared <shared.rst>`_
+
+    * `theme <theme.rst>`_
+
 Be sure to check our `additional resources <additional-resources.rst>`_ for further reading on how to improve access to and readability of your modules.
 
 

--- a/.documentation/index.rst
+++ b/.documentation/index.rst
@@ -7,13 +7,18 @@ This project is an example of directory structure in an Angular application but 
 Directory Structure
 -------------------
 
-* `~/media <media.rst>`_
-* `~/src/theme <theme.rst>`_
-* `~/src/app/core <core.rst>`_
-* `~/src/app/data <data.rst>`_
-* `~/src/app/layout <layout.rst>`_
-* `~/src/app/module <module.rst>`_
-* `~/src/app/shared <shared.rst>`_
+Documentation is organized by the directories defined by this repository
+
+~
+├── `media <media.rst>`_
+└── src
+    ├── app
+    │   ├── `core <core.rst>`_
+    │   ├── `data <data.rst>`_
+    │   ├── `layout <layout.rst>`_
+    │   ├── `module <module.rst>`_
+    │   └── `shared <shared.rst>`_
+    └── `theme <theme.rst>`_
     
 Be sure to check our `additional resources <additional-resources.rst>`_ for further reading on how to improve access to and readability of your modules.
 

--- a/.documentation/layout.rst
+++ b/.documentation/layout.rst
@@ -5,24 +5,24 @@ Layout Directory
 
 `~/src/app/layout <../src/app/layout>`_
 
-The layout directory is a container of components which are declared in the 
-AppModule.  The directory contains page-level components of content such as a 
-common footer, navigation, and header.  It also contains page layouts for the 
+The layout directory is a container of components which are declared in the
+AppModule.  The directory contains page-level components of content such as a
+common footer, navigation, and header.  It also contains page layouts for the
 different sections of your application.
 
-Components like footer and navigation are handled the Angular way by importing 
+Components like footer and navigation are handled the Angular way by importing
 them into a template:
 
 .. code-block:: html
 
   <app-nav></app-nav>
-  
 
-Layouts are handled in a rather clever way.  By using child routes a top level 
-route can define a layout to be used for its children.  Each module has its own 
-routing so the top level ``AppRoutingModule`` includes the module as a child of 
-a route.  This code block is taken from ``app-routing.module.ts`` and trimmed of 
-extra content:
+
+Layouts are handled in a rather clever way.  By using child routes a top level
+route can define a layout to be used for its children.  Each module has its own
+routing so the top level ``AppRoutingModule`` includes the module as a child of
+a route.  This code block is taken from ``app-routing.module.ts`` and trimmed
+of extra content:
 
 .. code-block:: ts
 
@@ -39,8 +39,8 @@ extra content:
     }
 
 
-When a route is called at ``/dashboard`` the ``ContentLayoutComponent`` is used 
-as a layout and handling of the routing is handed off to the HomeModule.  
+When a route is called at ``/dashboard`` the ``ContentLayoutComponent`` is used
+as a layout and handling of the routing is handed off to the HomeModule.
 The ``ContentLayoutComponent`` has a ``router-outlet``:
 
 .. code-block:: html
@@ -48,21 +48,21 @@ The ``ContentLayoutComponent`` has a ``router-outlet``:
   <div [class]="theme">
     <div class="mat-app-background">
       <app-nav></app-nav>
-  
+
       <div class="container">
         <router-outlet></router-outlet>
       </div>
-  
+
       <app-footer (changeTheme)="onThemeChange($event)"></app-footer>
     </div>
   </div>
 
 
-This ``router-outlet`` is used to display a route and component defined in the 
+This ``router-outlet`` is used to display a route and component defined in the
 routing of the ``HomeRoutingModule``:
 
 .. code-block: ts
-  
+
   export const routes: Routes = [
     {
       path: '',
@@ -81,7 +81,7 @@ routing of the ``HomeRoutingModule``:
       ]
     }
   ];
-  
+
   @NgModule({
       imports: [RouterModule.forChild(routes)],
       exports: [RouterModule]
@@ -89,5 +89,5 @@ routing of the ``HomeRoutingModule``:
   export class HomeRoutingModule { }
 
 
-So the routes are ``/dashboard`` and ``/dashboard/projects/:id`` and they use 
+So the routes are ``/dashboard`` and ``/dashboard/projects/:id`` and they use
 the ContentLayoutComponent for their layout.

--- a/.documentation/layout.rst
+++ b/.documentation/layout.rst
@@ -5,21 +5,24 @@ Layout Directory
 
 `~/src/app/layout <../src/app/layout>`_
 
-The layout directory is a container of components which are declared in the AppModule. 
-The directory contains page-level components of content such as a common footer, navigation, and header. 
-It also contains page layouts for the different sections of your application.
+The layout directory is a container of components which are declared in the 
+AppModule.  The directory contains page-level components of content such as a 
+common footer, navigation, and header.  It also contains page layouts for the 
+different sections of your application.
 
-Components like footer and navigation are handled the Angular way by importing them into a template:
+Components like footer and navigation are handled the Angular way by importing 
+them into a template:
 
 .. code-block:: html
 
   <app-nav></app-nav>
   
 
-Layouts are handled in a rather clever way.  By using child routes a top level route can define
-a layout to be used for its children.  Each module has its own routing so the top level ``AppRoutingModule``
-includes the module as a child of a route.  This code block is taken from ``app-routing.module.ts`` and 
-trimmed of extra content:
+Layouts are handled in a rather clever way.  By using child routes a top level 
+route can define a layout to be used for its children.  Each module has its own 
+routing so the top level ``AppRoutingModule`` includes the module as a child of 
+a route.  This code block is taken from ``app-routing.module.ts`` and trimmed of 
+extra content:
 
 .. code-block:: ts
 
@@ -36,8 +39,9 @@ trimmed of extra content:
     }
 
 
-When a route is called at ``/dashboard`` the ``ContentLayoutComponent`` is used as a layout and 
-handling of the routing is handed off to the HomeModule.  The ``ContentLayoutComponent`` has a ``router-outlet``:
+When a route is called at ``/dashboard`` the ``ContentLayoutComponent`` is used 
+as a layout and handling of the routing is handed off to the HomeModule.  
+The ``ContentLayoutComponent`` has a ``router-outlet``:
 
 .. code-block:: html
 
@@ -54,7 +58,8 @@ handling of the routing is handed off to the HomeModule.  The ``ContentLayoutCom
   </div>
 
 
-This ``router-outlet`` is used to display a route and component defined in the routing of the ``HomeRoutingModule``:
+This ``router-outlet`` is used to display a route and component defined in the 
+routing of the ``HomeRoutingModule``:
 
 .. code-block: ts
   
@@ -84,5 +89,5 @@ This ``router-outlet`` is used to display a route and component defined in the r
   export class HomeRoutingModule { }
 
 
-So the routes are ``/dashboard`` and ``/dashboard/projects/:id`` and they use the ContentLayoutComponent for
-their layout.
+So the routes are ``/dashboard`` and ``/dashboard/projects/:id`` and they use 
+the ContentLayoutComponent for their layout.

--- a/.documentation/media.rst
+++ b/.documentation/media.rst
@@ -5,6 +5,10 @@ Media Directory
 
 `~/media <../media>`_
 
-The ``media`` directory is used to store supporting files for the application.  Things like requiremenets docs, text outlines, etc.  This is the junk drawer for the project.  
+The ``media`` directory is used to store supporting files for the application.  
+Things like requiremenets docs, text outlines, etc.  This is the junk drawer for 
+the project.  
 
-``media`` can be used for compiling bootstrap.  Extract the bootstrap project into media then modify the ``scss/_variables.scss`` then compile.  Link the dist boostrap.min.css into your assets directory and you've got a custom bootstrap.
+``media`` can be used for compiling bootstrap.  Extract the bootstrap project 
+into media then modify the ``scss/_variables.scss`` then compile.  Link the dist 
+boostrap.min.css into your assets directory and you've got a custom bootstrap.

--- a/.documentation/media.rst
+++ b/.documentation/media.rst
@@ -5,10 +5,11 @@ Media Directory
 
 `~/media <../media>`_
 
-The ``media`` directory is used to store supporting files for the application.  
-Things like requiremenets docs, text outlines, etc.  This is the junk drawer for 
-the project.  
+The ``media`` directory is used to store supporting files for the application.
+Things like requiremenets docs, text outlines, etc.  This is the junk drawer
+for the project.
 
-``media`` can be used for compiling bootstrap.  Extract the bootstrap project 
-into media then modify the ``scss/_variables.scss`` then compile.  Link the dist 
-boostrap.min.css into your assets directory and you've got a custom bootstrap.
+``media`` can be used for compiling bootstrap.  Extract the bootstrap project
+into media then modify the ``scss/_variables.scss`` then compile.  Link the
+dist boostrap.min.css into your assets directory and you've got a custom
+bootstrap.

--- a/.documentation/module.rst
+++ b/.documentation/module.rst
@@ -6,14 +6,17 @@ Module Directory
 `~/src/app/module <../src/app/module>`_
 
 
-The module directory contains a collection of modules which are each independent of each other.  This allows
-Angular to load only the module it requires to display the request thereby saving bandwidth and speeding the
-entire application.  
+The module directory contains a collection of modules which are each independent 
+of each other.  This allows Angular to load only the module it requires to 
+display the request thereby saving bandwidth and speeding the entire 
+application.  
 
-In order to accomplish this each module must have its own routing which is a ``loadChildren`` route 
-resource defined in the ``AppRoutingModule``.  This is also covered in the `layout documentation <layout.rst>`_
+In order to accomplish this each module must have its own routing which is a 
+``loadChildren`` route resource defined in the ``AppRoutingModule``.  This is 
+also covered in the `layout documentation <layout.rst>`_
 
-A route can have children and each child can have a loadChildren property.  From ``app-routing.module.ts``:
+A route can have children and each child can have a loadChildren property.  
+From ``app-routing.module.ts``:
 
 .. code-block:: ts
 
@@ -40,8 +43,8 @@ A route can have children and each child can have a loadChildren property.  From
     ]
   },
   
-Each child must have its own base path from which it can load children from a module in the ``module`` directory.
-Here is the routing for the About page:
+Each child must have its own base path from which it can load children from a 
+module in the ``module`` directory.  Here is the routing for the About page:
 
 .. code-block:: ts
 
@@ -63,6 +66,8 @@ Here is the routing for the About page:
   })
   export class AboutRoutingModule { }
   
-It is necessary to add the child routes to the RouterModule through ``forChild``.
+It is necessary to add the child routes to the RouterModule 
+through ``forChild``.
 
-Besides routing any module inside the ``module`` directory can be as simple or complicated as you wish.
+Besides routing any module inside the ``module`` directory can be as simple or 
+complicated as you wish.

--- a/.documentation/module.rst
+++ b/.documentation/module.rst
@@ -5,17 +5,16 @@ Module Directory
 
 `~/src/app/module <../src/app/module>`_
 
+The module directory contains a collection of modules which are each
+independent of each other.  This allows Angular to load only the module it
+requires to display the request thereby saving bandwidth and speeding the
+entire application.
 
-The module directory contains a collection of modules which are each independent 
-of each other.  This allows Angular to load only the module it requires to 
-display the request thereby saving bandwidth and speeding the entire 
-application.  
-
-In order to accomplish this each module must have its own routing which is a 
-``loadChildren`` route resource defined in the ``AppRoutingModule``.  This is 
+In order to accomplish this each module must have its own routing which is a
+``loadChildren`` route resource defined in the ``AppRoutingModule``.  This is
 also covered in the `layout documentation <layout.rst>`_
 
-A route can have children and each child can have a loadChildren property.  
+A route can have children and each child can have a loadChildren property.
 From ``app-routing.module.ts``:
 
 .. code-block:: ts
@@ -42,32 +41,32 @@ From ``app-routing.module.ts``:
     }
     ]
   },
-  
-Each child must have its own base path from which it can load children from a 
+
+Each child must have its own base path from which it can load children from a
 module in the ``module`` directory.  Here is the routing for the About page:
 
 .. code-block:: ts
 
   import { NgModule } from '@angular/core';
   import { Routes, RouterModule } from '@angular/router';
-  
+
   import { AboutComponent } from './pages/about/about.component';
-  
+
   const routes: Routes = [
     {
       path: '',
       component: AboutComponent
     }
   ];
-  
+
   @NgModule({
     imports: [RouterModule.forChild(routes)],
     exports: [RouterModule]
   })
   export class AboutRoutingModule { }
-  
-It is necessary to add the child routes to the RouterModule 
+
+It is necessary to add the child routes to the RouterModule
 through ``forChild``.
 
-Besides routing any module inside the ``module`` directory can be as simple or 
+Besides routing any module inside the ``module`` directory can be as simple or
 complicated as you wish.

--- a/.documentation/shared.rst
+++ b/.documentation/shared.rst
@@ -5,10 +5,12 @@ Shared Module
 
 `~/src/app/shared <../src/app/shared>`_
 
-The shared module contains classes and resources which are always loaded when the application is loaded and
-which are shared between the main application and dynamically loaded modules.  By always loading with the
+The shared module contains classes and resources which are always loaded when 
+the application is loaded and which are shared between the main application 
+and dynamically loaded modules.  By always loading with the
 application the shared components are ready whenever a module requests them.
 
-The shared module is a good place to import and export the ``FormsModule`` and the ``ReactiveFormsModule``.
-It is also good for the ``FontAwesomeModule`` and any other resource used by some modules 
-some of the time but not all modules all of the time.
+The shared module is a good place to import and export the ``FormsModule`` 
+and the ``ReactiveFormsModule``.  It is also good for the ``FontAwesomeModule`` 
+and any other resource used by some modules some of the time but not all modules 
+all of the time.

--- a/.documentation/shared.rst
+++ b/.documentation/shared.rst
@@ -5,12 +5,12 @@ Shared Module
 
 `~/src/app/shared <../src/app/shared>`_
 
-The shared module contains classes and resources which are always loaded when 
-the application is loaded and which are shared between the main application 
+The shared module contains classes and resources which are always loaded when
+the application is loaded and which are shared between the main application
 and dynamically loaded modules.  By always loading with the
 application the shared components are ready whenever a module requests them.
 
-The shared module is a good place to import and export the ``FormsModule`` 
-and the ``ReactiveFormsModule``.  It is also good for the ``FontAwesomeModule`` 
-and any other resource used by some modules some of the time but not all modules 
-all of the time.
+The shared module is a good place to import and export the ``FormsModule``
+and the ``ReactiveFormsModule``.  It is also good for the ``FontAwesomeModule``
+and any other resource used by some modules some of the time but not all
+modules all of the time.

--- a/.documentation/theme.rst
+++ b/.documentation/theme.rst
@@ -1,9 +1,9 @@
 `<< Documentation Index <index.rst>`_
 
-Theming 
+Theming
 =======
 
 `~/src/theme <../src/theme>`_
 
-The ``~/app/main.scss`` pulls in the themes in the ``~/app/theme`` directory 
+The ``~/app/main.scss`` pulls in the themes in the ``~/app/theme`` directory
 as well as bootstrap and Angular material theming.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "restructuredtext.builtDocumentationPath": "${workspaceRoot}/dist/documentation",
+  "restructuredtext.updateOnTextChanged"    : "true",
+  "restructuredtext.updateDelay"            : 300,
+  "restructuredtext.sphinxBuildPath": null,
+  "restructuredtext.confPath": "${workspaceFolder}/.documentation"
+}

--- a/README.md
+++ b/README.md
@@ -21,25 +21,5 @@ Demonstration Application
 Install
 -------
 
-This project is an example of directory structure but it is also a working application.
+This project is an example of directory structure but it is also a working application.  [See The Documentation](.documentation/index.rst) for instructions to run it locally.
 
-This project assumes you have already created other projects for Angular on your system and have the required node and typescript libraries already installed.
-
-After cloneing locally and `cd` to the project directory, install the node libraries:
-
-```sh
-  npm install
-```
-
-
-Scripts
--------
-
-```
-* npm start     -> Run dev. server on http://localhost:4200/
-* npm run build -> Lint code and build app for production in dist folder
-* npm run test  -> Run unit tests via Karma in watch mode
-* npm test:ci   -> Lint code and run unit tests once for continuous integration
-* npm run e2e   -> Run e2e tests using Protractor
-* npm run lint  -> Lint code
-```


### PR DESCRIPTION
* Move instructions for install and running to documentation index
* Organize documentation as a bulleted list.  I tried using the `tree` command but the output didn't line up.
* Formatted all docs to pass restructuredText (rst) lint.
* Added https://docs.restructuredtext.net/index.html to my local vscode for easier previewing of .rst files.