### PR TITLE
Feature/readme restructure (master branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,10 @@ Angular Folder Structure - Highly Scalable
 
 ![docs badge](https://readthedocs.org/projects/angular-folder-structure/badge/?version=latest)
 
-This project is inspired by the article on ITNEXT called
-"[How to define a highly scalable folder structure for your Angular project](https://itnext.io/choosing-a-highly-scalable-folder-structure-in-angular-d987de65ec7)"
-by Mathis Garberg. Based on best practices from the community, other github
+Based on best practices from the community, other github
 Angular projects, developer experience from production Angular projects, and
-contributors to this reposiory, this project goal is to *create a skeleton
-structure which is flexible for projects big or small*.
-
-![login screen screenshot](https://raw.githubusercontent.com/mathisGarberg/angular-folder-structure/master/media/screenshot.png)
+contributors to this reposiory, this project goal is to *create an Angular
+skeleton structure which is flexible for projects big or small*.
 
 Tree Structure
 --------------
@@ -35,10 +31,19 @@ Documentation
 -------------
 
 [Read The Documentation](https://angular-folder-structure.readthedocs.io/en/latest/#)
-for details on each part of the directory structure.
+for through details on each part of the directory structure.
 
 Demonstration Application
 -------------------------
 
 [See The Application](https://mathisgarberg.github.io/angular-folder-structure/)
 in action.  
+
+![login screen screenshot](https://raw.githubusercontent.com/mathisGarberg/angular-folder-structure/master/media/screenshot.png)
+
+Inspiration
+-----------
+
+This project is inspired by the article on ITNEXT called
+"[How to define a highly scalable folder structure for your Angular project](https://itnext.io/choosing-a-highly-scalable-folder-structure-in-angular-d987de65ec7)"
+by Mathis Garberg.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@ Angular Folder Structure - Highly Scalable
 
 ![docs badge](https://readthedocs.org/projects/angular-folder-structure/badge/?version=latest)
 
-Based on best practices from the community, other github
-Angular projects, developer experience from production Angular projects, and
-contributors to this reposiory, this project goal is to *create an Angular
-skeleton structure which is flexible for projects big or small*.
+Based on best practices from the community,
+[other github Angular projects](https://angular-folder-structure.readthedocs.io/en/latest/furthur-reading.html#alternative-directory-structure-projects)
+, developer experience from production Angular projects, and contributors to
+this reposiory, this project goal is to *create an Angular skeleton structure
+which is flexible for projects big or small*.
+
+Included are both an [example application](https://mathisgarberg.github.io/angular-folder-structure/) and [documentation](https://angular-folder-structure.readthedocs.io/en/latest/#) on each change.
 
 Tree Structure
 --------------
@@ -31,7 +34,7 @@ Documentation
 -------------
 
 [Read The Documentation](https://angular-folder-structure.readthedocs.io/en/latest/#)
-for through details on each part of the directory structure.
+for thorough details on each part of the directory structure.
 
 Demonstration Application
 -------------------------


### PR DESCRIPTION
 Move description and link to original blog article to bottom of README.md The blog article is a long ways away from the repository now and I think should not be promoted before this new project

  Move application screenshot below Demonstration Application in README.md This would open up the README and push the link to the docs higher in the page.