### PR TITLE
Feature/Add path alias for data module directory

### DIFF
--- a/src/app/core/service/auth.service.ts
+++ b/src/app/core/service/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { of, Observable, throwError } from 'rxjs';
 
-import { User } from '../../data/schema/user';
+import { User } from '@data/schema/user';
 
 interface LoginContextInterface {
   username: string;

--- a/src/app/modules/home/page/home.component.ts
+++ b/src/app/modules/home/page/home.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { ProjectService } from '../../../data/service/project.service';
-import { Project } from '../../../data/schema/project';
+import { ProjectService } from '@data/service/project.service';
+import { Project } from '@data/schema/project';
 import { Observable } from 'rxjs';
 
 import { MyModalComponent } from '../modal/my-modal.component';

--- a/src/app/modules/home/page/project-details/project-details.component.ts
+++ b/src/app/modules/home/page/project-details/project-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { Project } from '../../../../data/schema/project';
+import { Project } from '@data/schema/project';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 

--- a/src/app/modules/home/page/project-item/project-item.component.ts
+++ b/src/app/modules/home/page/project-item/project-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 
-import { Project } from '../../../../data/schema/project';
+import { Project } from '@data/schema/project';
 
 @Component({
   selector: 'app-project-item',

--- a/src/app/modules/home/project-resolver.service.ts
+++ b/src/app/modules/home/project-resolver.service.ts
@@ -3,8 +3,8 @@ import { ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot } from '@a
 import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
-import { Project } from '../../data/schema/project';
-import { ProjectService } from '../../data/service/project.service';
+import { Project } from '@data/schema/project';
+import { ProjectService } from '@data/service/project.service';
 
 @Injectable({
   providedIn: 'root'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,9 @@
       ],
       "@modules/*": [
         "app/modules/*"
+      ],
+      "@data/*": [
+        "app/data/*"
       ]
     },
     "lib": [


### PR DESCRIPTION
The imports of the services and schema classes from the data directory were hard to read and maintain, especially from deep within the modules directory. With the additional path alias the imports look much cleaner.